### PR TITLE
Minor concurrency fix

### DIFF
--- a/iuv/iuv.py
+++ b/iuv/iuv.py
@@ -249,7 +249,7 @@ def run(args, stop_all_event=None):
 
         try:
             generator_thread.join(timeout=3)
-            generation_done = True
+            generation_done = not generator_thread.is_alive()
         except TimeoutError:
             generation_done = False
 
@@ -299,8 +299,9 @@ if __name__ == '__main__':
         else:
             logging.info("Time taken: " + str(timeout_watch.sum()))
         stop_event.set()
-        try:
-            running_thread.join(5)
-        except TimeoutError:
-            logging.warning("Timeout error when waiting for main thread")
+        while running_thread.is_alive():
+            try:
+                running_thread.join(5)
+            except TimeoutError:
+                logging.warning("Timeout error when waiting for main thread")
 

--- a/iuv/iuv.py
+++ b/iuv/iuv.py
@@ -15,7 +15,6 @@ import utils
 import shutil
 
 from threading import Event, Thread
-from multiprocessing.context import TimeoutError
 from time import sleep
 
 from test_validation import ValidationConfig
@@ -247,11 +246,8 @@ def run(args, stop_all_event=None):
 
         validation_result = validator_module.check_inputs(filename, generator_thread, stop_all_event)
 
-        try:
-            generator_thread.join(timeout=3)
-            generation_done = not generator_thread.is_alive()
-        except TimeoutError:
-            generation_done = False
+        generator_thread.join(timeout=3)
+        generation_done = not generator_thread.is_alive()
 
         if validation_result.is_positive():
             test_name = os.path.basename(validation_result.test_vector.origin)
@@ -300,8 +296,5 @@ if __name__ == '__main__':
             logging.info("Time taken: " + str(timeout_watch.sum()))
         stop_event.set()
         while running_thread.is_alive():
-            try:
-                running_thread.join(5)
-            except TimeoutError:
-                logging.warning("Timeout error when waiting for main thread")
+            running_thread.join(5)
 


### PR DESCRIPTION
Thread.join wouldn't throw a TimeoutError if the timeout was reached (https://docs.python.org/3/library/threading.html#threading.Thread.join). Instead, it is necessary to check whether the thread is alive.