### PR TITLE
Explicitly call __gcov_flush() before abnormal termination (abort())

### DIFF
--- a/tbf/harness_generation.py
+++ b/tbf/harness_generation.py
@@ -83,7 +83,7 @@ class HarnessCreator(object):
                             b': strcpy(inp_var, "', value, b'"); break;\n'
                         ])
                         # yapf: enable
-                    definitions += b"        default: abort();\n"
+                    definitions += b"        default: {\n #ifdef TBF_GCOV\n __gcov_flush();\n#endif\nabort();}\n"
                     definitions += b"    }\n"
                     definitions += b"    access_counter++;\n"
 

--- a/tbf/testcase_processing.py
+++ b/tbf/testcase_processing.py
@@ -379,7 +379,7 @@ class CoverageMeasuringExecutionRunner(ExecutionRunner):
                          c_version='gnu11'):
         cmd = super()._get_compile_cmd(program_file, harness_file, output_file,
                                        c_version)
-        cmd += ['-fprofile-arcs', '-ftest-coverage']
+        cmd += ['-fprofile-arcs', '-ftest-coverage', '-DTBF_GCOV']
 
         return cmd
 

--- a/tbf/utils.py
+++ b/tbf/utils.py
@@ -357,7 +357,7 @@ def get_env_with_path_added(path_addition):
 
 
 def get_assume_method():
-    return 'void __VERIFIER_assume(int cond) {\n    if(!cond) {\n        abort();\n    }\n}\n'
+    return 'void __VERIFIER_assume(int cond) {\n    if(!cond) {\n #ifdef TBF_GCOV\n  __gcov_flush();\n#endif\n   abort();\n    }\n}\n'
 
 
 def get_error_method_definition(error_method):
@@ -790,6 +790,7 @@ extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__))
     __attribute__ ((__malloc__));
 extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
     size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern void __gcov_flush(void);
 
 """
 


### PR DESCRIPTION
Abnormal termination of an application does not flush gcov data.
This leads to incomplete coverage data.

Explicitly flush coverage data, if:
* `__VERIFIER_assume` is invoked
* not enough input data has been generated.